### PR TITLE
Gnome 3.30 compatibility. fixes #143

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -877,8 +877,8 @@ MoveWindow.prototype = {
 
   _loadScreenData: function() {
     // get monitor(s) geometry
-    this._primary = global.screen.get_primary_monitor();
-    let numMonitors = global.screen.get_n_monitors();
+    this._primary = this._utils.getScreen().get_primary_monitor();
+    let numMonitors = this._utils.getScreen().get_n_monitors();
 
     this._screens = [];
     // only tested with 2 screen setup
@@ -890,7 +890,7 @@ MoveWindow.prototype = {
       if (Main.layoutManager.getWorkAreaForMonitor) {
         geom = Main.layoutManager.getWorkAreaForMonitor(i);
       } else {
-        geom = global.screen.get_monitor_geometry(i)
+        geom = this._utils.getScreen().get_monitor_geometry(i)
       }
 
       let primary = (i == this._primary);
@@ -931,13 +931,14 @@ MoveWindow.prototype = {
 
     this._loadScreenData();
 
-    this._screenListener = global.screen.connect("monitors-changed",
+    this._screenListener = this._utils.getMonitorManager().connect("monitors-changed",
       Lang.bind(this, this._loadScreenData));
 
-    this._workaresChangedListener = global.screen.connect("workareas-changed",
+    this._workaresChangedListener = this._utils.getScreen().connect("workareas-changed",
       Lang.bind(this, this._loadScreenData));
 
-    this._windowCreatedListener = global.screen.get_display().connect_after('window-created',
+    // this._windowCreatedListener = global.screen.get_display().connect_after('window-created',
+    this._windowCreatedListener = global.display.connect_after('window-created',
       Lang.bind(this, this._moveConfiguredWhenCreated)
     );
 
@@ -997,17 +998,17 @@ MoveWindow.prototype = {
   destroy: function() {
 
     if (this._windowCreatedListener) {
-      global.screen.get_display().disconnect(this._windowCreatedListener);
+      global.display.disconnect(this._windowCreatedListener);
       this._windowCreatedListener = false;
     }
 
     if (this._screenListener) {
-      global.screen.disconnect(this._screenListener);
+      this._utils.getScreen().disconnect(this._screenListener);
       this._screenListener = false;
     }
 
     if (this.__workaresChangedListener) {
-      global.screen.disconnect(this._workaresChangedListener);
+      this._utils.getScreen().disconnect(this._workaresChangedListener);
       this._workaresChangedListener = false;
     }
 

--- a/moveFocus.js
+++ b/moveFocus.js
@@ -7,6 +7,9 @@ const Clutter = imports.gi.Clutter;
 const Lightbox = imports.ui.lightbox;
 const Tweener = imports.ui.tweener;
 
+const Extension = imports.misc.extensionUtils.getCurrentExtension();
+const Utils = Extension.imports.utils;
+
 function MoveFocus(utils, screens) {
   this._init(utils, screens);
 }
@@ -293,14 +296,14 @@ MoveFocus.prototype = {
       return;
     }
 
-		let screen = global.screen;
-    let display = screen.get_display();
+    let screen = this._utils.getWorkspaceManager();
+    let display = global.display;
 
     let allWin;
      if (this._isVersion14) {
       allWin = display.sort_windows_by_stacking(display.get_tab_list(Meta.TabList.NORMAL_ALL, screen.get_active_workspace()));
     } else {
-      allWin = display.sort_windows_by_stacking(display.get_tab_list(Meta.TabList.NORMAL_ALL, screen, screen.get_active_workspace()));
+      allWin = screen.get_display().sort_windows_by_stacking(display.get_tab_list(Meta.TabList.NORMAL_ALL, screen, screen.get_active_workspace()));
     }
 
 		focusWin.lower();
@@ -372,7 +375,7 @@ MoveFocus.prototype = {
     let screenGeo;
     do {
       rightMostScreen++;
-      screenGeo = global.screen.get_monitor_geometry(rightMostScreen);
+      screenGeo = this._utils.getScreen().get_monitor_geometry(rightMostScreen);
     } while (screenGeo.x != 0 && screenGeo.y != 0);
 
     // Prevent Looping
@@ -416,8 +419,8 @@ MoveFocus.prototype = {
   },
 
   _getCurrentScreenIndex: function(win) {
-    if (global.screen.get_monitor_index_for_rect) {
-      return global.screen.get_monitor_index_for_rect(win.get_frame_rect());
+    if (this._utils.getScreen().get_monitor_index_for_rect) {
+      return this._utils.getScreen().get_monitor_index_for_rect(win.get_frame_rect());
     }
 
     let screenLen = this._screens.length;
@@ -477,7 +480,7 @@ MoveFocus.prototype = {
   _getWindowList: function() {
     let display = global.screen.get_display();
     if (this._isVersion14) {
-      return display.get_tab_list(Meta.TabList.NORMAL_ALL, global.screen.get_active_workspace());
+      return display.get_tab_list(Meta.TabList.NORMAL_ALL, this._utils.getWorkspaceManager().get_active_workspace());
     } else {
       return display.get_tab_list(Meta.TabList.NORMAL_ALL, global.screen, global.screen.get_active_workspace());
     }

--- a/moveWorkspace.js
+++ b/moveWorkspace.js
@@ -55,7 +55,7 @@ MoveWorkspace.prototype = {
     Main.wm._workspaceTracker._checkWorkspaces = this._myCheckWorkspaces;
 
     // Connect after so the handler from ShellWindowTracker has already run
-    let display = global.screen.get_display();
+    let display = global.display;
     this._windowCreatedId = display.connect_after('window-created', Lang.bind(this, this._findAndMove));
   },
 
@@ -69,7 +69,7 @@ MoveWorkspace.prototype = {
     }
 
     if (this._windowCreatedId) {
-      global.screen.get_display().disconnect(this._windowCreatedId);
+      global.display.disconnect(this._windowCreatedId);
       this._windowCreatedId = 0;
     }
   },
@@ -98,7 +98,7 @@ MoveWorkspace.prototype = {
     let sequences = Shell.WindowTracker.get_default().get_startup_sequences();
     for (i = 0; i < sequences.length; i++) {
       let index = sequences[i].get_workspace();
-      if (index >= 0 && index <= global.screen.n_workspaces) {
+      if (index >= 0 && index <= Utils.getWorkspaceManager().n_workspaces) {
         emptyWorkspaces[index] = false;
       }
     }
@@ -117,17 +117,17 @@ MoveWorkspace.prototype = {
 
     // If we don't have an empty workspace at the end, add one
     if (!emptyWorkspaces[emptyWorkspaces.length -1]) {
-      global.screen.append_new_workspace(false, global.get_current_time());
+      Utils.getWorkspaceManager().append_new_workspace(false, global.get_current_time());
       emptyWorkspaces.push(false);
     }
 
-    let activeWorkspaceIndex = global.screen.get_active_workspace_index();
+    let activeWorkspaceIndex = Utils.getWorkspaceManager().get_active_workspace_index();
     emptyWorkspaces[activeWorkspaceIndex] = false;
 
     // Delete other empty workspaces; do it from the end to avoid index changes
     for (i = emptyWorkspaces.length - 2; i >= 0; i--) {
       if (emptyWorkspaces[i]) {
-        global.screen.remove_workspace(this._workspaces[i], global.get_current_time());
+        Utils.getWorkspaceManager().remove_workspace(this._workspaces[i], global.get_current_time());
       } else {
         break;
       }
@@ -162,7 +162,7 @@ MoveWorkspace.prototype = {
       if (this._utils.getBoolean(appPath + ".moveWorkspace", false)) {
         let targetWorkspace = this._utils.getNumber(appPath + ".targetWorkspace", 1) - 1;
 
-        if (targetWorkspace >= global.screen.n_workspaces) {
+        if (targetWorkspace >= Utils.getWorkspaceManager().n_workspaces) {
           this._ensureAtLeastWorkspaces(targetWorkspace, window);
         }
 
@@ -184,9 +184,9 @@ MoveWorkspace.prototype = {
 
 
   _ensureAtLeastWorkspaces: function(num, window) {
-    for (let j = global.screen.n_workspaces; j <= num; j++) {
+    for (let j = Utils.getWorkspaceManager().n_workspaces; j <= num; j++) {
       window.change_workspace_by_index(j-1, false);
-      global.screen.append_new_workspace(false, 0);
+      Utils.getWorkspaceManager().append_new_workspace(false, 0);
     }
   }
 };

--- a/utils.js
+++ b/utils.js
@@ -335,5 +335,20 @@ Utils.prototype = {
   showErrorMessage: function(title, message) {
     global.log("ERROR: " + title + " " + message);
     //throw new Error(title + ' ' message);
+  },
+
+  getScreen() {
+    return global.screen || global.display;
+  },
+
+  getWorkspaceManager() {
+    return global.screen || global.workspace_manager;
+  },
+
+  getMonitorManager() {
+    // imported here since prefs.js cannot import Meta
+    const Meta = imports.gi.Meta;
+    return global.screen || Meta.MonitorManager.get();
   }
+
 };


### PR DESCRIPTION
fixes #143

adapt to following commits:
https://gitlab.gnome.org/GNOME/gnome-shell/commit/47ea10b7c976abb1b9ab4f34da87abb1e36855fe
https://gitlab.gnome.org/GNOME/gnome-shell-extensions/commit/6583eae6225039b6b711918eff3a7cd0d03a42ca

Tested on fedora 29 pre-beta / 3.30 RC (3.29.91)

needs testing on 3.28 at least, I did try to preserve compatibility as much as possible.

*note for the review*: when putting the import gi.Meta at the top of utils.js, I had the same error as https://github.com/home-sweet-gnome/dash-to-panel/issues/154 (I guess, because utils is imported by prefs.js)