### PR TITLE
Fix 3.30: global.screen undefined

### DIFF
--- a/moveFocus.js
+++ b/moveFocus.js
@@ -478,11 +478,11 @@ MoveFocus.prototype = {
   },
 
   _getWindowList: function() {
-    let display = global.screen.get_display();
+    let display = global.display;
     if (this._isVersion14) {
       return display.get_tab_list(Meta.TabList.NORMAL_ALL, this._utils.getWorkspaceManager().get_active_workspace());
     } else {
-      return display.get_tab_list(Meta.TabList.NORMAL_ALL, global.screen, global.screen.get_active_workspace());
+      return display.get_tab_list(Meta.TabList.NORMAL_ALL, this._utils.getScreen(), this._utils.getWorkspaceManager().get_active_workspace());
     }
   },
 


### PR DESCRIPTION
Moving focus didn't work and gave "global.screen undefined": there were still some "global.screen" to fix (ref #143)