### PR TITLE
Fix gap below south edge when moving to corner

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -532,7 +532,7 @@ MoveWindow.prototype = {
     if (direction.indexOf("s") == -1) {
       y = s.y;
     } else {
-      y = (s.totalHeight - pos.height);
+      y = s.y + (s.totalHeight - pos.height);
     }
 
     if (direction.indexOf("w") == -1) {


### PR DESCRIPTION
Hi,
This patch fixes a problem I had on Ubuntu 18.04.1 (Gnome 3.28.2) when moving windows to corners that left a gap between the bottom of the window and the bottom of the screen. A 27 pixel gap in my case (single monitor at 1080x1920).

I use this extension only to move windows and **not** to resize them (`__moveToCornerKeepSize`). It seems likely the same code change would be needed in the `_moveToCorner()` function, but since I don't use it I've not tested it to see if the same issue exists there.

Thanks,

Peter.