### PR TITLE
Fix useWidth and useHeight mismatch when moving to corner

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -496,6 +496,8 @@ MoveWindow.prototype = {
       return;
     }
 
+    useWidth = useHeight = Math.min(useWidth, useHeight);
+
     let x, y, width, height;
     if (this._utils.changeCornerWidth()) {
       x = widths[useWidth].x;

--- a/extension.js
+++ b/extension.js
@@ -496,7 +496,9 @@ MoveWindow.prototype = {
       return;
     }
 
-    useWidth = useHeight = Math.min(useWidth, useHeight);
+    if (this._utils.changeCornerBoth()) {
+      useWidth = useHeight = Math.min(useWidth, useHeight);
+    }
 
     let x, y, width, height;
     if (this._utils.changeCornerWidth()) {

--- a/utils.js
+++ b/utils.js
@@ -179,6 +179,11 @@ Utils.prototype = {
     return this.getNumber(this.CORNER_CHANGE, 0) == 3;
   },
 
+  changeCornerBoth: function() {
+    let val = this.getNumber(this.CORNER_CHANGE, 0);
+    return val == 0 || val == 4;
+  },
+
   getNorthHeights: function() {
     let ret = this._addToArray([], this.getNumber("north-height-0", 50) / 100);
     ret = this._addToArray(ret, this.getNumber("north-height-1", 66) / 100);


### PR DESCRIPTION
I've stumbled on this issue where you move a window to a corner (e.g. keep hitting Super+3), sometimes the size is not one quarter of the screen. Even though, with default settings > Width & Height > the First value is set to 50% for all directions. @Socob has documented this issue at: https://github.com/negesti/gnome-shell-extensions-negesti/issues/151#issuecomment-466799980

To reproduce the issue, take a window (does not matter which program's it is) and then:
1. Press Super+5 to move it to center
2. Use mouse to resize the window to only one direction (e.g. change only height, but not width)
3. Keep pressing e.g. Super+3 to move the window to one corner and cycle through all possible sizes
4. None of the sizes you get is 50% both in width and height

The issue doesn't occur if in 2nd step you don't either resize the window, or you change both its width AND height.

To debug the issue I added a [few log lines to extension.js](https://gist.github.com/jhakonen/4a4f02fff920d4232e598c98f26916b8). The issue seems to occur when useWidth and useHeight are in different values. 

Example of doing the above steps to reproduce the issue I get:
```
$ journalctl /usr/bin/gnome-shell -f -n 0 2>/dev/null | grep gnome-shell
kesä 22 16:04:58 msilinux gnome-shell[4635]: _moveToCorner :: moving to corner, keeping size
kesä 22 16:04:59 msilinux gnome-shell[4635]: _moveToCorner :: resize with: useWidth=1, useHeight=0
kesä 22 16:05:00 msilinux gnome-shell[4635]: _moveToCorner :: resize with: useWidth=2, useHeight=1
kesä 22 16:05:01 msilinux gnome-shell[4635]: _moveToCorner :: resize with: useWidth=0, useHeight=2
kesä 22 16:05:02 msilinux gnome-shell[4635]: _moveToCorner :: resize with: useWidth=1, useHeight=0
```
So, the first resize takes:
* Width value from Settings > Width & Height > East width > Second
* Height value from Settings > Width & Height > South height > First

The width value should come from First, not Second. So useWidth should be 0, not 1. 

Here's another example where in 2nd step I changed the window size in both directions, and this time the first resize of the window is correctly one quarter of the screen:
```
$ journalctl /usr/bin/gnome-shell -f -n 0 2>/dev/null | grep gnome-shell
kesä 22 16:11:31 msilinux gnome-shell[4635]: _moveToCorner :: moving to corner, keeping size
kesä 22 16:11:32 msilinux gnome-shell[4635]: _moveToCorner :: resize with: useWidth=0, useHeight=0
kesä 22 16:11:34 msilinux gnome-shell[4635]: _moveToCorner :: resize with: useWidth=1, useHeight=1
kesä 22 16:11:35 msilinux gnome-shell[4635]: _moveToCorner :: resize with: useWidth=2, useHeight=2
kesä 22 16:11:36 msilinux gnome-shell[4635]: _moveToCorner :: resize with: useWidth=0, useHeight=0
```
This PR fixes the issue by ensuring that the useWidth and useHeight have same value before the window is resized, keeping the values in sync.
