### PR TITLE
Accept 1, true as boolean true as well

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -201,7 +201,7 @@ export default class PutWindowUtils {
     } else {
       ret = this.getParameter(name);
     }
-    return ret === 'true' || ret === '1';
+    return ret == 1 || ret === true || ret === 'true' || ret === '1';
   }
 
   getNumber(name, defaultValue) {


### PR DESCRIPTION
I found after upgrading noble, this plugin no longer worked. 

Even I added bind key and enabled via UI, it disappeared if I open the window again,

Strange enough, dconf has right value.

```
putWindow@clemens.lab21.org$ dconf read /org/gnome/shell/extensions/org-lab21-putwindow/put-to-side-n-enabled
1
```
and after inserting few logs, I found it accepts 1 as int not string.

I'm not sure it's right solution, but at least this change makes me work again.